### PR TITLE
fix isMediaStream function

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -73,5 +73,5 @@ function readAudio (opts, onAbort) {
 }
 
 function isMediaStream (obj) {
-  return obj && obj.toString() === '[object MediaStream]'
+  return obj && !!MediaStream && obj instanceof MediaStream
 }

--- a/browser.js
+++ b/browser.js
@@ -73,5 +73,5 @@ function readAudio (opts, onAbort) {
 }
 
 function isMediaStream (obj) {
-  return obj && !!MediaStream && obj instanceof MediaStream
+  return obj && !!window.MediaStream && obj instanceof window.MediaStream
 }


### PR DESCRIPTION
was broken on Firefox where obj.toString() === '[object LocalMediaStream]'

this seems to work and should be more future-proof

/cc @pietgeursen
