### PR TITLE
Fix arecord path.

### DIFF
--- a/main.js
+++ b/main.js
@@ -80,7 +80,7 @@ function parseRawAudio (opts) {
 function defaultOpts (opts) {
   opts = defined(opts, {})
   opts.soxPath = defined(opts.soxPath, 'sox')
-  opts.arecordPath = defined(opts.arecordPath, 'arecord')
+  opts.arecordPath = defined(opts.arecordPath, '/usr/bin/arecord')
   opts.inFile = defined(opts.inFile, '-d')
   opts.dtype = defined(opts.dtype, 'int32')
   opts.channels = defined(opts.channels, 1)


### PR DESCRIPTION
Sorry for the second PR, I just noticed that `fs.existsSync()` won't work without a full path.